### PR TITLE
fixed transfer mosaic fee bug

### DIFF
--- a/src/nem1-sdk/src/Model/Transactions/TransferTransaction.cs
+++ b/src/nem1-sdk/src/Model/Transactions/TransferTransaction.cs
@@ -238,7 +238,7 @@ namespace io.nem1.sdk.Model.Transactions
                          
                          if (s <= 10000 && d == 0)
                          {
-                             Fee += 1000000;
+                             Fee += 50000;
                          }
                          else
                          {


### PR DESCRIPTION
If total supply is less than or equal to 10000 and divisibility is 0. 
The fee should be always be 0.05 XEM which is 50000.